### PR TITLE
Fix #54 userstate.emotes를 string으로 취급하던 문제 수정

### DIFF
--- a/speech.html
+++ b/speech.html
@@ -209,7 +209,7 @@
                         msg.from = userstate["display-name"];
                         msg.text = message;
                         msg.color = userstate.color;
-                        if(userstate.emotes !== null) msg.emotes = userstate.emotes;
+                        if(userstate['emotes-raw'] !== null) msg.emotes = userstate['emotes-raw'];
                         msg.action = userstate["message-type"] == "action";
                         msg.badges = userstate["badges-raw"] ?? [];
                         msg.streamer = msg.badges.indexOf("broadcaster/1") !== -1;


### PR DESCRIPTION
심각도: 보통

userstate.emotes를 string으로 취급하던 문제 수정하였습니다. (#54)
아래 결과와 같이 userstate.emotes는 Object이고 userstate['emotes-raw']가 string입니다.

```JSON
{
  "emotes": {
    "86": [
      "0-9"
    ],
    "64138": [
      "11-19"
    ],
    "303179118": [
      "24-33"
    ],
    "303179119": [
      "35-42"
    ],
    "555555584": [
      "21-22"
    ]
  },
  "emotes-raw": "303179118:24-33/303179119:35-42/86:0-9/64138:11-19/555555584:21-22",
}
```
그리고 emotes가 없을 때에는 null이고 기존의 코드에 이에 대한 처리가 있어서 별도의 nullish 병합 연산자는 적용하지 않았습니다.
```JSON
{
  "emotes": null,
  "emotes-raw": null
}
```
https://github.com/Lastorder-DC/chatreader-kor/blob/050754b7f72dfbfa61f9b525b0e0d1eb596ebf10/tts.js#L731-L735