### PR TITLE
#57 #58 귓속말을 읽어주는 문제 수정

### DIFF
--- a/speech.html
+++ b/speech.html
@@ -204,6 +204,7 @@
                     
                     client.on("message", function(channel, userstate, message, self) {
                         if (self) return;
+                        if (userstate["message-type"] !== "chat") return;
 
                         let msg = {}
                         msg.from = userstate["display-name"];


### PR DESCRIPTION
심각도: 높음

#57 #58 귓속말을 읽어주는 문제 수정

그나마 제일 최신인 2019-03-03일자 개발 문서에서
https://github.com/tmijs/docs/blob/gh-pages/_posts/v1.4.2/2019-03-03-Events.md#message

`client.on("message",...)`  이벤트는 "action", "chat", "whisper" 3개 유형의 메세지를 받고  userstate["message-type"] 에 유형이 저장되어있습니다.
> 액션 예시
/me TEXTThis command will remove the colon that typically appears after your chat name and italicize your message text. Can be used to denote **action** in the third-person.
https://help.twitch.tv/s/article/chat-commands?language=en_US#:~:text=the%20Block%20button.-,/me%20TEXT,-This%20command%20will

> ch0494_dev1 하하하 <-'action'
ch0494_dev1: 하하하 <- 'chat'

userstate["message-type"]가 위 3개 유형중 어느것도 아닌 default 상황일 때가 무슨상황인지는 모르겠습니다.